### PR TITLE
Entities: Spy arguments storing refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,20 +78,17 @@ func testMultiplyStub() {
 
 	let result = multiplierTestDouble.multiply(3, 3)
 	XCTAssertEqual(result, 5) // Returns `true`
-
 }
 ```
 
 ## Spy
 
-`Spy` is a `Stub` which is very useful when you need to assert what arguments has been passed to certain method or property. By using `invoke([...])` method `Spy` will record incoming values.
-
-> ℹ️ Note: Currently `Spy` each call will rewrite call arguments thus only the last one will be available.
+`Spy` is a `Stub` which is very useful when you need to assert what arguments has been passed to certain method or property. By using `invoke(arguments: [...])` method `Spy` will record incoming values.
 
 There is two ways of working with `Spy`:
 
 - Use Guava's builtin `XCTAssertCalled` functions
-- Use `Spy`'s `callCount` and `callArguments` properties directly with testing library of your choice.
+- Use `Spy`'s `calls` property directly with testing library of your choice.
 
 #### Asserts that `Spy` was called
 
@@ -106,7 +103,7 @@ func testSpyCalled() {
 
     XCTAssertCalledOnce(spy)
     // OR
-    XCTAssertEqual(spy.callCount, 1)
+    XCTAssertEqual(spy.calls.count, 1)
 }
 ```
 #### Asserts that `Spy` was called with certain arguments
@@ -119,11 +116,14 @@ func testSpyCalledWithArguments() {
 
     let result = multiplierTestDouble.multiply(3, 3)
 
-	 XCTAssertCalled(spy, with: (3, 3))
+    XCTAssertCalled(spy, with: (3, 3))
 	 // OR
-	 let (a, b) = spy.calledArguments.as(Int.self, Int.self)
-	 XCTAssertEqual(a, 3)
-	 XCTAssertEqual(b, 3)
+    guard let (a, b) = spy.calls.last?.arguments.as(Int.self, Int.self) else {
+        XCTFail("Method was not called")
+        return
+    }
+    XCTAssertEqual(a, 3)
+    XCTAssertEqual(b, 3)
 }
 ```
 

--- a/Sources/Entities/Spy.swift
+++ b/Sources/Entities/Spy.swift
@@ -1,8 +1,7 @@
 /// A `Spy` is a `Stub` that also records information about call.
 public final class Spy<Value> {
 
-    public private(set) var callArguments = [Argument]()
-    public private(set) var callCount = 0
+    public private(set) var calls = [MethodCall]()
 
     private var stub: Stub<Value>
 
@@ -14,9 +13,14 @@ public final class Spy<Value> {
 extension Spy: Invokable {
 
     public func invoke(arguments: [Any]) -> Value {
-        callArguments = arguments.map { Argument(value: $0) }
-        callCount += 1
+        let callArguments = arguments.map { Argument(value: $0) }
+        calls.append(MethodCall(arguments: callArguments))
 
         return stub.invoke(arguments: arguments)
     }
+}
+
+public struct MethodCall {
+
+    public let arguments: [Argument]
 }

--- a/Sources/XCTAssert/XCTAssert.swift
+++ b/Sources/XCTAssert/XCTAssert.swift
@@ -4,7 +4,7 @@
 ///   - file: The file in which failure occurred. Defaults to the file name of the test case in which this function was called.
 ///   - line: The line number on which failure occurred. Defaults to the line number on which this function was called.
 public func XCTAssertCalled<Out>(_ spy: Spy<Out>, file: StaticString = #file, line: UInt = #line) {
-    if spy.callCount == .zero {
+    if spy.calls.isEmpty {
         FailureReporter.handler.handleFailure(.expectedToBeCalled,
                                               location: ReportLocation(file: file, line: line))
     }
@@ -16,7 +16,7 @@ public func XCTAssertCalled<Out>(_ spy: Spy<Out>, file: StaticString = #file, li
 ///   - file: The file in which failure occurred. Defaults to the file name of the test case in which this function was called.
 ///   - line: The line number on which failure occurred. Defaults to the line number on which this function was called.
 public func XCTAssertNotCalled<Out>(_ spy: Spy<Out>, file: StaticString = #file, line: UInt = #line) {
-    if spy.callCount != .zero {
+    if !spy.calls.isEmpty {
         FailureReporter.handler.handleFailure(.expectedToNotBeCalled,
                                               location: ReportLocation(file: file, line: line))
     }
@@ -28,8 +28,8 @@ public func XCTAssertNotCalled<Out>(_ spy: Spy<Out>, file: StaticString = #file,
 ///   - file: The file in which failure occurred. Defaults to the file name of the test case in which this function was called.
 ///   - line: The line number on which failure occurred. Defaults to the line number on which this function was called.
 public func XCTAssertCalledOnce<Out>(_ spy: Spy<Out>, file: StaticString = #file, line: UInt = #line) {
-    if spy.callCount != 1 {
-        FailureReporter.handler.handleFailure(.expectedToBeCalledOnce(calledCount: spy.callCount),
+    if spy.calls.count != 1 {
+        FailureReporter.handler.handleFailure(.expectedToBeCalledOnce(calledCount: spy.calls.count),
                                               location: ReportLocation(file: file, line: line))
     }
 }
@@ -40,9 +40,9 @@ public func XCTAssertCalledOnce<Out>(_ spy: Spy<Out>, file: StaticString = #file
 ///   - file: The file in which failure occurred. Defaults to the file name of the test case in which this function was called.
 ///   - line: The line number on which failure occurred. Defaults to the line number on which this function was called.
 public func XCTAssertCalled<Out>(_ spy: Spy<Out>, times: Int, file: StaticString = #file, line: UInt = #line) {
-    if spy.callCount != times {
+    if spy.calls.count != times {
         FailureReporter.handler.handleFailure(.expectedToBeCalledTimes(expectedCount: times,
-                                                                       calledCount: spy.callCount),
+                                                                       calledCount: spy.calls.count),
                                               location: ReportLocation(file: file, line: line))
     }
 }
@@ -57,8 +57,10 @@ public func XCTAssertCalled<Out, A>(_ spy: Spy<Out>,
                                     with argument: A,
                                     file: StaticString = #file,
                                     line: UInt = #line) where A: Equatable {
-    guard spy.callArguments.assertSize(of: 1, file: file, line: line),
-        spy.callArguments[0].assertEqual(argument, position: .first, file: file, line: line) else { return }
+    XCTAssertCalled(spy, file: file, line: line)
+    guard let callArguments = spy.calls.last?.arguments,
+        callArguments.assertSize(of: 1, file: file, line: line),
+        callArguments[0].assertEqual(argument, position: .first, file: file, line: line) else { return }
 }
 
 /// Asserts that spy was called with two arguments.
@@ -72,9 +74,11 @@ public func XCTAssertCalled<Out, A, B>(_ spy: Spy<Out>,
                                        file: StaticString = #file,
                                        line: UInt = #line)
     where A: Equatable, B: Equatable {
-        guard spy.callArguments.assertSize(of: 2, file: file, line: line),
-            spy.callArguments[0].assertEqual(arguments.0, position: .first, file: file, line: line),
-            spy.callArguments[1].assertEqual(arguments.1, position: .second, file: file, line: line) else { return }
+        XCTAssertCalled(spy, file: file, line: line)
+        guard let callArguments = spy.calls.last?.arguments,
+            callArguments.assertSize(of: 2, file: file, line: line),
+            callArguments[0].assertEqual(arguments.0, position: .first, file: file, line: line),
+            callArguments[1].assertEqual(arguments.1, position: .second, file: file, line: line) else { return }
 }
 
 /// Asserts that spy was called with three arguments.
@@ -88,10 +92,12 @@ public func XCTAssertCalled<Out, A, B, C>(_ spy: Spy<Out>,
                                           file: StaticString = #file,
                                           line: UInt = #line)
     where A: Equatable, B: Equatable, C: Equatable {
-        guard spy.callArguments.assertSize(of: 3, file: file, line: line),
-            spy.callArguments[0].assertEqual(arguments.0, position: .first, file: file, line: line),
-            spy.callArguments[1].assertEqual(arguments.1, position: .second, file: file, line: line),
-            spy.callArguments[2].assertEqual(arguments.2, position: .third, file: file, line: line) else { return }
+        XCTAssertCalled(spy, file: file, line: line)
+        guard let callArguments = spy.calls.last?.arguments,
+            callArguments.assertSize(of: 3, file: file, line: line),
+            callArguments[0].assertEqual(arguments.0, position: .first, file: file, line: line),
+            callArguments[1].assertEqual(arguments.1, position: .second, file: file, line: line),
+            callArguments[2].assertEqual(arguments.2, position: .third, file: file, line: line) else { return }
 }
 
 /// Asserts that spy was called with four arguments.
@@ -105,11 +111,13 @@ public func XCTAssertCalled<Out, A, B, C, D>(_ spy: Spy<Out>,
                                              file: StaticString = #file,
                                              line: UInt = #line)
     where A: Equatable, B: Equatable, C: Equatable, D: Equatable {
-        guard spy.callArguments.assertSize(of: 4, file: file, line: line),
-            spy.callArguments[0].assertEqual(arguments.0, position: .first, file: file, line: line),
-            spy.callArguments[1].assertEqual(arguments.1, position: .second, file: file, line: line),
-            spy.callArguments[2].assertEqual(arguments.2, position: .third, file: file, line: line),
-            spy.callArguments[3].assertEqual(arguments.3, position: .fourth, file: file, line: line) else { return }
+        XCTAssertCalled(spy, file: file, line: line)
+        guard let callArguments = spy.calls.last?.arguments,
+            callArguments.assertSize(of: 4, file: file, line: line),
+            callArguments[0].assertEqual(arguments.0, position: .first, file: file, line: line),
+            callArguments[1].assertEqual(arguments.1, position: .second, file: file, line: line),
+            callArguments[2].assertEqual(arguments.2, position: .third, file: file, line: line),
+            callArguments[3].assertEqual(arguments.3, position: .fourth, file: file, line: line) else { return }
 }
 
 /// Asserts that spy was called with five arguments.
@@ -123,12 +131,14 @@ public func XCTAssertCalled<Out, A, B, C, D, E>(_ spy: Spy<Out>,
                                                 file: StaticString = #file,
                                                 line: UInt = #line)
     where A: Equatable, B: Equatable, C: Equatable, D: Equatable, E: Equatable {
-        guard spy.callArguments.assertSize(of: 5, file: file, line: line),
-            spy.callArguments[0].assertEqual(arguments.0, position: .first, file: file, line: line),
-            spy.callArguments[1].assertEqual(arguments.1, position: .second, file: file, line: line),
-            spy.callArguments[2].assertEqual(arguments.2, position: .third, file: file, line: line),
-            spy.callArguments[3].assertEqual(arguments.3, position: .fourth, file: file, line: line),
-            spy.callArguments[4].assertEqual(arguments.4, position: .fifth, file: file, line: line) else { return }
+        XCTAssertCalled(spy, file: file, line: line)
+        guard let callArguments = spy.calls.last?.arguments,
+            callArguments.assertSize(of: 5, file: file, line: line),
+            callArguments[0].assertEqual(arguments.0, position: .first, file: file, line: line),
+            callArguments[1].assertEqual(arguments.1, position: .second, file: file, line: line),
+            callArguments[2].assertEqual(arguments.2, position: .third, file: file, line: line),
+            callArguments[3].assertEqual(arguments.3, position: .fourth, file: file, line: line),
+            callArguments[4].assertEqual(arguments.4, position: .fifth, file: file, line: line) else { return }
 }
 
 /// Asserts that spy was called with six arguments.
@@ -142,13 +152,15 @@ public func XCTAssertCalled<Out, A, B, C, D, E, F>(_ spy: Spy<Out>,
                                                    file: StaticString = #file,
                                                    line: UInt = #line)
     where A: Equatable, B: Equatable, C: Equatable, D: Equatable, E: Equatable, F: Equatable {
-        guard spy.callArguments.assertSize(of: 6, file: file, line: line),
-            spy.callArguments[0].assertEqual(arguments.0, position: .first, file: file, line: line),
-            spy.callArguments[1].assertEqual(arguments.1, position: .second, file: file, line: line),
-            spy.callArguments[2].assertEqual(arguments.2, position: .third, file: file, line: line),
-            spy.callArguments[3].assertEqual(arguments.3, position: .fourth, file: file, line: line),
-            spy.callArguments[4].assertEqual(arguments.4, position: .fifth, file: file, line: line),
-            spy.callArguments[5].assertEqual(arguments.5, position: .sixth, file: file, line: line) else { return }
+        XCTAssertCalled(spy, file: file, line: line)
+        guard let callArguments = spy.calls.last?.arguments,
+            callArguments.assertSize(of: 6, file: file, line: line),
+            callArguments[0].assertEqual(arguments.0, position: .first, file: file, line: line),
+            callArguments[1].assertEqual(arguments.1, position: .second, file: file, line: line),
+            callArguments[2].assertEqual(arguments.2, position: .third, file: file, line: line),
+            callArguments[3].assertEqual(arguments.3, position: .fourth, file: file, line: line),
+            callArguments[4].assertEqual(arguments.4, position: .fifth, file: file, line: line),
+            callArguments[5].assertEqual(arguments.5, position: .sixth, file: file, line: line) else { return }
 }
 
 /// Asserts that spy was called with seven arguments.
@@ -162,14 +174,16 @@ public func XCTAssertCalled<Out, A, B, C, D, E, F, G>(_ spy: Spy<Out>,
                                                       file: StaticString = #file,
                                                       line: UInt = #line)
     where A: Equatable, B: Equatable, C: Equatable, D: Equatable, E: Equatable, F: Equatable, G: Equatable {
-        guard spy.callArguments.assertSize(of: 7, file: file, line: line),
-            spy.callArguments[0].assertEqual(arguments.0, position: .first, file: file, line: line),
-            spy.callArguments[1].assertEqual(arguments.1, position: .second, file: file, line: line),
-            spy.callArguments[2].assertEqual(arguments.2, position: .third, file: file, line: line),
-            spy.callArguments[3].assertEqual(arguments.3, position: .fourth, file: file, line: line),
-            spy.callArguments[4].assertEqual(arguments.4, position: .fifth, file: file, line: line),
-            spy.callArguments[5].assertEqual(arguments.5, position: .sixth, file: file, line: line),
-            spy.callArguments[6].assertEqual(arguments.6, position: .seventh, file: file, line: line) else { return }
+        XCTAssertCalled(spy, file: file, line: line)
+        guard let callArguments = spy.calls.last?.arguments,
+            callArguments.assertSize(of: 7, file: file, line: line),
+            callArguments[0].assertEqual(arguments.0, position: .first, file: file, line: line),
+            callArguments[1].assertEqual(arguments.1, position: .second, file: file, line: line),
+            callArguments[2].assertEqual(arguments.2, position: .third, file: file, line: line),
+            callArguments[3].assertEqual(arguments.3, position: .fourth, file: file, line: line),
+            callArguments[4].assertEqual(arguments.4, position: .fifth, file: file, line: line),
+            callArguments[5].assertEqual(arguments.5, position: .sixth, file: file, line: line),
+            callArguments[6].assertEqual(arguments.6, position: .seventh, file: file, line: line) else { return }
 }
 
 /// Asserts that spy was called with eight arguments.
@@ -184,15 +198,17 @@ public func XCTAssertCalled<Out, A, B, C, D, E, F, G, H>(_ spy: Spy<Out>,
                                                          line: UInt = #line)
     where A: Equatable, B: Equatable, C: Equatable, D: Equatable, E: Equatable, F: Equatable, G: Equatable,
     H: Equatable {
-        guard spy.callArguments.assertSize(of: 8, file: file, line: line),
-            spy.callArguments[0].assertEqual(arguments.0, position: .first, file: file, line: line),
-            spy.callArguments[1].assertEqual(arguments.1, position: .second, file: file, line: line),
-            spy.callArguments[2].assertEqual(arguments.2, position: .third, file: file, line: line),
-            spy.callArguments[3].assertEqual(arguments.3, position: .fourth, file: file, line: line),
-            spy.callArguments[4].assertEqual(arguments.4, position: .fifth, file: file, line: line),
-            spy.callArguments[5].assertEqual(arguments.5, position: .sixth, file: file, line: line),
-            spy.callArguments[6].assertEqual(arguments.6, position: .seventh, file: file, line: line),
-            spy.callArguments[7].assertEqual(arguments.7, position: .eighth, file: file, line: line) else { return }
+        XCTAssertCalled(spy, file: file, line: line)
+        guard let callArguments = spy.calls.last?.arguments,
+            callArguments.assertSize(of: 8, file: file, line: line),
+            callArguments[0].assertEqual(arguments.0, position: .first, file: file, line: line),
+            callArguments[1].assertEqual(arguments.1, position: .second, file: file, line: line),
+            callArguments[2].assertEqual(arguments.2, position: .third, file: file, line: line),
+            callArguments[3].assertEqual(arguments.3, position: .fourth, file: file, line: line),
+            callArguments[4].assertEqual(arguments.4, position: .fifth, file: file, line: line),
+            callArguments[5].assertEqual(arguments.5, position: .sixth, file: file, line: line),
+            callArguments[6].assertEqual(arguments.6, position: .seventh, file: file, line: line),
+            callArguments[7].assertEqual(arguments.7, position: .eighth, file: file, line: line) else { return }
 }
 
 /// Asserts that spy was called with nine arguments.
@@ -207,14 +223,16 @@ public func XCTAssertCalled<Out, A, B, C, D, E, F, G, H, I>(_ spy: Spy<Out>,
                                                             line: UInt = #line)
     where A: Equatable, B: Equatable, C: Equatable, D: Equatable, E: Equatable, F: Equatable, G: Equatable,
     H: Equatable, I: Equatable {
-        guard spy.callArguments.assertSize(of: 9, file: file, line: line),
-            spy.callArguments[0].assertEqual(arguments.0, position: .first, file: file, line: line),
-            spy.callArguments[1].assertEqual(arguments.1, position: .second, file: file, line: line),
-            spy.callArguments[2].assertEqual(arguments.2, position: .third, file: file, line: line),
-            spy.callArguments[3].assertEqual(arguments.3, position: .fourth, file: file, line: line),
-            spy.callArguments[4].assertEqual(arguments.4, position: .fifth, file: file, line: line),
-            spy.callArguments[5].assertEqual(arguments.5, position: .sixth, file: file, line: line),
-            spy.callArguments[6].assertEqual(arguments.6, position: .seventh, file: file, line: line),
-            spy.callArguments[7].assertEqual(arguments.7, position: .eighth, file: file, line: line),
-            spy.callArguments[8].assertEqual(arguments.8, position: .ninth, file: file, line: line) else { return }
+        XCTAssertCalled(spy, file: file, line: line)
+        guard let callArguments = spy.calls.last?.arguments,
+            callArguments.assertSize(of: 9, file: file, line: line),
+            callArguments[0].assertEqual(arguments.0, position: .first, file: file, line: line),
+            callArguments[1].assertEqual(arguments.1, position: .second, file: file, line: line),
+            callArguments[2].assertEqual(arguments.2, position: .third, file: file, line: line),
+            callArguments[3].assertEqual(arguments.3, position: .fourth, file: file, line: line),
+            callArguments[4].assertEqual(arguments.4, position: .fifth, file: file, line: line),
+            callArguments[5].assertEqual(arguments.5, position: .sixth, file: file, line: line),
+            callArguments[6].assertEqual(arguments.6, position: .seventh, file: file, line: line),
+            callArguments[7].assertEqual(arguments.7, position: .eighth, file: file, line: line),
+            callArguments[8].assertEqual(arguments.8, position: .ninth, file: file, line: line) else { return }
 }


### PR DESCRIPTION
The current approach of storing call arguments directly in `Spy` is not flexible enough. 
This PR adds `MethodCall` entity that stores call arguments. 
Now `Spy` stores an array of method calls. That gives us the ability to count calls out-of-box and now `Spy` stores all calls instead of the last one.  