### PR TITLE
guava: Assertion mechanism refactoring

### DIFF
--- a/.github/workflows/swiftlint.yml
+++ b/.github/workflows/swiftlint.yml
@@ -14,3 +14,5 @@ jobs:
       - uses: actions/checkout@v1
       - name: SwiftLint
         uses: norio-nomura/action-swiftlint@3.1.0
+        with:
+          args: --strict

--- a/Sources/Entities/Argument.swift
+++ b/Sources/Entities/Argument.swift
@@ -59,16 +59,16 @@ public struct Argument {
     /// - Parameters:
     ///   - expectedValue: Expected value of type `T`, where `T` is `Equatable`.
     ///   - position: Position of argument in method.
-    public func assertEqual<T>(_ expectedValue: T) -> Result<Void, Failure> where T: Equatable {
+    public func assertEqual<T>(_ expectedValue: T) -> Result<Void, AssertionFailure> where T: Equatable {
         guard let castedValue = asSafe(T.self) else {
-            let typeMismatchFailure: Failure = .typeMismatch(expectedType: "\(T.self)",
+            let typeMismatchFailure: AssertionFailure = .typeMismatch(expectedType: "\(T.self)",
                                                              receivedType: storedType,
                                                              argument: position.name)
             return .failure(typeMismatchFailure)
         }
 
         if castedValue != expectedValue {
-            let valueMismatchFailure: Failure = .valueMismatch(expectedValue: "\(expectedValue)",
+            let valueMismatchFailure: AssertionFailure = .valueMismatch(expectedValue: "\(expectedValue)",
                                                                receivedValue: "\(castedValue)",
                                                                argument: position.name)
             return .failure(valueMismatchFailure)

--- a/Sources/Entities/Array+Argument.swift
+++ b/Sources/Entities/Array+Argument.swift
@@ -3,34 +3,16 @@ extension Array where Element == Argument {
     /// Asserts that arguments array is greater than or equal to expected size.
     /// - Parameters:
     ///   - expectedSize: Expected arguments array size.
-    ///   - strict: Indicates that failure should be handled as fatal error.
-    ///   - file: The file in which failure occurred. Defaults to the file name of the test case in which this function was called.
-    ///   - line: The line number on which failure occurred. Defaults to the line number on which this function was called.
-    @discardableResult
-    func assertSize(of expectedSize: Int,
-                    strict: Bool = false,
-                    file: StaticString = #file,
-                    line: UInt = #line) -> Bool {
+    func assertSize(of expectedSize: Int) -> Result<Void, Failure> {
         guard count >= expectedSize else {
             let failure: Failure = .argumentsCountMismatch(expectedCount: expectedSize,
                                                            providedCount: count)
 
-            if strict {
-                FailureReporter.handler.handleFatalError(failure,
-                                                         location: ReportLocation(file: file, line: line))
-            } else {
-                FailureReporter.handler.handleFailure(failure,
-                                                      location: ReportLocation(file: file, line: line))
-            }
-
-            return false
+            return .failure(failure)
         }
 
-        return true
+        return .success(())
     }
-}
-
-extension Array where Element == Argument {
 
     /// Returns argument casted to specific type.
     ///
@@ -45,10 +27,11 @@ extension Array where Element == Argument {
     public func `as`<A>(_ type: A.Type,
                         file: StaticString = #file,
                         line: UInt = #line) -> A {
-        assertSize(of: 1, strict: true, file: file, line: line)
-        let first = self[0].castStrictly(to: type, argumentPosition: .first)
+        if case .failure(let failure) = assertSize(of: 1) {
+            FailureReporter.handler.handleFatalError(failure, location: .init(file: file, line: line))
+        }
 
-        return (first)
+        return self[0].castStrictly(to: type, file: file, line: line)
     }
 
     /// Returns two arguments casted to specific types.
@@ -66,10 +49,11 @@ extension Array where Element == Argument {
                            _ secondType: B.Type,
                            file: StaticString = #file,
                            line: UInt = #line) -> (A, B) {
-        assertSize(of: 2, strict: true, file: file, line: line)
-
-        let first = self[0].castStrictly(to: firstType, argumentPosition: .first)
-        let second = self[1].castStrictly(to: secondType, argumentPosition: .second)
+        if case .failure(let failure) = assertSize(of: 2) {
+            FailureReporter.handler.handleFatalError(failure, location: .init(file: file, line: line))
+        }
+        let first = self[0].castStrictly(to: firstType, file: file, line: line)
+        let second = self[1].castStrictly(to: secondType, file: file, line: line)
 
         return (first, second)
     }
@@ -91,11 +75,12 @@ extension Array where Element == Argument {
                               _ thirdType: C.Type,
                               file: StaticString = #file,
                               line: UInt = #line) -> (A, B, C) {
-        assertSize(of: 3, strict: true, file: file, line: line)
-
-        let first = self[0].castStrictly(to: firstType, argumentPosition: .first)
-        let second = self[1].castStrictly(to: secondType, argumentPosition: .second)
-        let third = self[2].castStrictly(to: thirdType, argumentPosition: .third)
+        if case .failure(let failure) = assertSize(of: 3) {
+            FailureReporter.handler.handleFatalError(failure, location: .init(file: file, line: line))
+        }
+        let first = self[0].castStrictly(to: firstType, file: file, line: line)
+        let second = self[1].castStrictly(to: secondType, file: file, line: line)
+        let third = self[2].castStrictly(to: thirdType, file: file, line: line)
 
         return (first, second, third)
     }
@@ -119,12 +104,13 @@ extension Array where Element == Argument {
                                  _ fourthType: D.Type,
                                  file: StaticString = #file,
                                  line: UInt = #line) -> (A, B, C, D) {
-        assertSize(of: 4, strict: true, file: file, line: line)
-
-        let first = self[0].castStrictly(to: firstType, argumentPosition: .first)
-        let second = self[1].castStrictly(to: secondType, argumentPosition: .second)
-        let third = self[2].castStrictly(to: thirdType, argumentPosition: .third)
-        let fourth = self[3].castStrictly(to: fourthType, argumentPosition: .fourth)
+        if case .failure(let failure) = assertSize(of: 4) {
+            FailureReporter.handler.handleFatalError(failure, location: .init(file: file, line: line))
+        }
+        let first = self[0].castStrictly(to: firstType, file: file, line: line)
+        let second = self[1].castStrictly(to: secondType, file: file, line: line)
+        let third = self[2].castStrictly(to: thirdType, file: file, line: line)
+        let fourth = self[3].castStrictly(to: fourthType, file: file, line: line)
 
         return (first, second, third, fourth)
     }
@@ -150,13 +136,14 @@ extension Array where Element == Argument {
                                     _ fifthType: E.Type,
                                     file: StaticString = #file,
                                     line: UInt = #line) -> (A, B, C, D, E) {
-        assertSize(of: 5, strict: true, file: file, line: line)
-
-        let first = self[0].castStrictly(to: firstType, argumentPosition: .first)
-        let second = self[1].castStrictly(to: secondType, argumentPosition: .second)
-        let third = self[2].castStrictly(to: thirdType, argumentPosition: .third)
-        let fourth = self[3].castStrictly(to: fourthType, argumentPosition: .fourth)
-        let fifth = self[4].castStrictly(to: fifthType, argumentPosition: .fifth)
+        if case .failure(let failure) = assertSize(of: 5) {
+            FailureReporter.handler.handleFatalError(failure, location: .init(file: file, line: line))
+        }
+        let first = self[0].castStrictly(to: firstType, file: file, line: line)
+        let second = self[1].castStrictly(to: secondType, file: file, line: line)
+        let third = self[2].castStrictly(to: thirdType, file: file, line: line)
+        let fourth = self[3].castStrictly(to: fourthType, file: file, line: line)
+        let fifth = self[4].castStrictly(to: fifthType, file: file, line: line)
 
         return (first, second, third, fourth, fifth)
     }
@@ -185,14 +172,15 @@ extension Array where Element == Argument {
                                        _ sixthType: F.Type,
                                        file: StaticString = #file,
                                        line: UInt = #line) -> (A, B, C, D, E, F) {
-        assertSize(of: 6, strict: true, file: file, line: line)
-
-        let first = self[0].castStrictly(to: firstType, argumentPosition: .first)
-        let second = self[1].castStrictly(to: secondType, argumentPosition: .second)
-        let third = self[2].castStrictly(to: thirdType, argumentPosition: .third)
-        let fourth = self[3].castStrictly(to: fourthType, argumentPosition: .fourth)
-        let fifth = self[4].castStrictly(to: fifthType, argumentPosition: .fifth)
-        let sixth = self[5].castStrictly(to: sixthType, argumentPosition: .sixth)
+        if case .failure(let failure) = assertSize(of: 6) {
+            FailureReporter.handler.handleFatalError(failure, location: .init(file: file, line: line))
+        }
+        let first = self[0].castStrictly(to: firstType, file: file, line: line)
+        let second = self[1].castStrictly(to: secondType, file: file, line: line)
+        let third = self[2].castStrictly(to: thirdType, file: file, line: line)
+        let fourth = self[3].castStrictly(to: fourthType, file: file, line: line)
+        let fifth = self[4].castStrictly(to: fifthType, file: file, line: line)
+        let sixth = self[5].castStrictly(to: sixthType, file: file, line: line)
 
         return (first, second, third, fourth, fifth, sixth)
     }
@@ -222,15 +210,16 @@ extension Array where Element == Argument {
                                           _ seventhType: G.Type,
                                           file: StaticString = #file,
                                           line: UInt = #line) -> (A, B, C, D, E, F, G) {
-        assertSize(of: 7, strict: true, file: file, line: line)
-
-        let first = self[0].castStrictly(to: firstType, argumentPosition: .first)
-        let second = self[1].castStrictly(to: secondType, argumentPosition: .second)
-        let third = self[2].castStrictly(to: thirdType, argumentPosition: .third)
-        let fourth = self[3].castStrictly(to: fourthType, argumentPosition: .fourth)
-        let fifth = self[4].castStrictly(to: fifthType, argumentPosition: .fifth)
-        let sixth = self[5].castStrictly(to: sixthType, argumentPosition: .sixth)
-        let seventh = self[6].castStrictly(to: seventhType, argumentPosition: .seventh)
+        if case .failure(let failure) = assertSize(of: 7) {
+            FailureReporter.handler.handleFatalError(failure, location: .init(file: file, line: line))
+        }
+        let first = self[0].castStrictly(to: firstType, file: file, line: line)
+        let second = self[1].castStrictly(to: secondType, file: file, line: line)
+        let third = self[2].castStrictly(to: thirdType, file: file, line: line)
+        let fourth = self[3].castStrictly(to: fourthType, file: file, line: line)
+        let fifth = self[4].castStrictly(to: fifthType, file: file, line: line)
+        let sixth = self[5].castStrictly(to: sixthType, file: file, line: line)
+        let seventh = self[6].castStrictly(to: seventhType, file: file, line: line)
 
         return (first, second, third, fourth, fifth, sixth, seventh)
     }
@@ -262,16 +251,17 @@ extension Array where Element == Argument {
                                              _ eighthType: H.Type,
                                              file: StaticString = #file,
                                              line: UInt = #line) -> (A, B, C, D, E, F, G, H) {
-        assertSize(of: 8, strict: true, file: file, line: line)
-
-        let first = self[0].castStrictly(to: firstType, argumentPosition: .first)
-        let second = self[1].castStrictly(to: secondType, argumentPosition: .second)
-        let third = self[2].castStrictly(to: thirdType, argumentPosition: .third)
-        let fourth = self[3].castStrictly(to: fourthType, argumentPosition: .fourth)
-        let fifth = self[4].castStrictly(to: fifthType, argumentPosition: .fifth)
-        let sixth = self[5].castStrictly(to: sixthType, argumentPosition: .sixth)
-        let seventh = self[6].castStrictly(to: seventhType, argumentPosition: .seventh)
-        let eighth = self[7].castStrictly(to: eighthType, argumentPosition: .eighth)
+        if case .failure(let failure) = assertSize(of: 8) {
+            FailureReporter.handler.handleFatalError(failure, location: .init(file: file, line: line))
+        }
+        let first = self[0].castStrictly(to: firstType, file: file, line: line)
+        let second = self[1].castStrictly(to: secondType, file: file, line: line)
+        let third = self[2].castStrictly(to: thirdType, file: file, line: line)
+        let fourth = self[3].castStrictly(to: fourthType, file: file, line: line)
+        let fifth = self[4].castStrictly(to: fifthType, file: file, line: line)
+        let sixth = self[5].castStrictly(to: sixthType, file: file, line: line)
+        let seventh = self[6].castStrictly(to: seventhType, file: file, line: line)
+        let eighth = self[7].castStrictly(to: eighthType, file: file, line: line)
 
         return (first, second, third, fourth, fifth, sixth, seventh, eighth)
     }
@@ -305,17 +295,18 @@ extension Array where Element == Argument {
                                                 _ ninthType: I.Type,
                                                 file: StaticString = #file,
                                                 line: UInt = #line) -> (A, B, C, D, E, F, G, H, I) {
-        assertSize(of: 9, strict: true, file: file, line: line)
-
-        let first = self[0].castStrictly(to: firstType, argumentPosition: .first)
-        let second = self[1].castStrictly(to: secondType, argumentPosition: .second)
-        let third = self[2].castStrictly(to: thirdType, argumentPosition: .third)
-        let fourth = self[3].castStrictly(to: fourthType, argumentPosition: .fourth)
-        let fifth = self[4].castStrictly(to: fifthType, argumentPosition: .fifth)
-        let sixth = self[5].castStrictly(to: sixthType, argumentPosition: .sixth)
-        let seventh = self[6].castStrictly(to: seventhType, argumentPosition: .seventh)
-        let eighth = self[7].castStrictly(to: eighthType, argumentPosition: .eighth)
-        let ninth = self[8].castStrictly(to: ninthType, argumentPosition: .ninth)
+        if case .failure(let failure) = assertSize(of: 9) {
+            FailureReporter.handler.handleFatalError(failure, location: .init(file: file, line: line))
+        }
+        let first = self[0].castStrictly(to: firstType, file: file, line: line)
+        let second = self[1].castStrictly(to: secondType, file: file, line: line)
+        let third = self[2].castStrictly(to: thirdType, file: file, line: line)
+        let fourth = self[3].castStrictly(to: fourthType, file: file, line: line)
+        let fifth = self[4].castStrictly(to: fifthType, file: file, line: line)
+        let sixth = self[5].castStrictly(to: sixthType, file: file, line: line)
+        let seventh = self[6].castStrictly(to: seventhType, file: file, line: line)
+        let eighth = self[7].castStrictly(to: eighthType, file: file, line: line)
+        let ninth = self[8].castStrictly(to: ninthType, file: file, line: line)
 
         return (first, second, third, fourth, fifth, sixth, seventh, eighth, ninth)
     }

--- a/Sources/Entities/Array+Argument.swift
+++ b/Sources/Entities/Array+Argument.swift
@@ -3,9 +3,9 @@ extension Array where Element == Argument {
     /// Asserts that arguments array is greater than or equal to expected size.
     /// - Parameters:
     ///   - expectedSize: Expected arguments array size.
-    func assertSize(of expectedSize: Int) -> Result<Void, Failure> {
+    func assertSize(of expectedSize: Int) -> Result<Void, AssertionFailure> {
         guard count >= expectedSize else {
-            let failure: Failure = .argumentsCountMismatch(expectedCount: expectedSize,
+            let failure: AssertionFailure = .argumentsCountMismatch(expectedCount: expectedSize,
                                                            providedCount: count)
 
             return .failure(failure)

--- a/Sources/Entities/Fake.swift
+++ b/Sources/Entities/Fake.swift
@@ -11,7 +11,9 @@ final class Fake<Value> {
 extension Fake: Invokable {
 
     func invoke(arguments: [Any]) -> Value {
-        let arguments = arguments.map { Argument(value: $0) }
+        let arguments = arguments
+            .enumerated()
+            .map { Argument(value: $0.element, position: .init($0.offset)) }
         return closure(arguments)
     }
 }

--- a/Sources/Entities/MethodCall.swift
+++ b/Sources/Entities/MethodCall.swift
@@ -2,12 +2,12 @@
 public struct MethodCall {
 
     /// Closure that stores assertion logic.
-    private let assertionClosure: (RecordedMethodCall) -> Result<Void, Failure>
+    private let assertionClosure: (RecordedMethodCall) -> Result<Void, AssertionFailure>
 
     /// Asserts that expected method call is equal to recorded one.
     /// - Parameter methodCall: Recorded method call.
     /// - Returns: Assertion result.
-    public func assertEquals(to methodCall: RecordedMethodCall) -> Result<Void, Failure> {
+    public func assertEquals(to methodCall: RecordedMethodCall) -> Result<Void, AssertionFailure> {
         return assertionClosure(methodCall)
     }
 }

--- a/Sources/Entities/MethodCall.swift
+++ b/Sources/Entities/MethodCall.swift
@@ -1,0 +1,93 @@
+/// Represents expected method call.
+public struct MethodCall {
+
+    /// Closure that stores assertion logic.
+    private let assertionClosure: (RecordedMethodCall) -> Result<Void, Failure>
+
+    /// Asserts that expected method call is equal to recorded one.
+    /// - Parameter methodCall: Recorded method call.
+    /// - Returns: Assertion result.
+    public func assertEquals(to methodCall: RecordedMethodCall) -> Result<Void, Failure> {
+        return assertionClosure(methodCall)
+    }
+}
+
+extension MethodCall {
+
+    /// Instantiates `MethodCall` with given argument.
+    /// - Parameter argument: An argument of type `A`, where `A` is `Equatable`.
+    public init<A>(argument: A) where A: Equatable {
+        assertionClosure = {
+            return $0.assertCalled(with: argument)
+        }
+    }
+
+    /// Instantiates `MethodCall` with given arguments.
+    /// - Parameter arguments: A tuple of types `A`, `B`, where these types are `Equatable`.
+    public init<A, B>(arguments: (A, B)) where A: Equatable, B: Equatable {
+        assertionClosure = {
+            return $0.assertCalled(with: arguments)
+        }
+    }
+
+    /// Instantiates `MethodCall` with given arguments.
+    /// - Parameter arguments: A tuple of types `A`, `B`, `C`, where these types are `Equatable`.
+    public init<A, B, C>(arguments: (A, B, C)) where A: Equatable, B: Equatable, C: Equatable {
+        assertionClosure = {
+            return $0.assertCalled(with: arguments)
+        }
+    }
+
+    /// Instantiates `MethodCall` with given arguments.
+    /// - Parameter arguments: A tuple of types `A`, `B`, `C`, `D`, where these types are `Equatable`.
+    public init<A, B, C, D>(arguments: (A, B, C, D)) where A: Equatable, B: Equatable, C: Equatable, D: Equatable {
+        assertionClosure = {
+            return $0.assertCalled(with: arguments)
+        }
+    }
+
+    /// Instantiates `MethodCall` with given arguments.
+    /// - Parameter arguments: A tuple of types `A`, `B`, `C`, `D`, `E`, where these types are `Equatable`.
+    public init<A, B, C, D, E>(arguments: (A, B, C, D, E)) where A: Equatable, B: Equatable, C: Equatable,
+        D: Equatable, E: Equatable {
+            assertionClosure = {
+                return $0.assertCalled(with: arguments)
+            }
+    }
+
+    /// Instantiates `MethodCall` with given arguments.
+    /// - Parameter arguments: A tuple of types `A`, `B`, `C`, `D`, `E`, `F`, where these types are `Equatable`.
+    public init<A, B, C, D, E, F>(arguments: (A, B, C, D, E, F)) where A: Equatable, B: Equatable, C: Equatable,
+        D: Equatable, E: Equatable, F: Equatable {
+            assertionClosure = {
+                return $0.assertCalled(with: arguments)
+            }
+    }
+
+    /// Instantiates `MethodCall` with given arguments.
+    /// - Parameter arguments: A tuple of types `A`, `B`, `C`, `D`, `E`, `F`, `G` where these types are `Equatable`.
+    public init<A, B, C, D, E, F, G>(arguments: (A, B, C, D, E, F, G)) where A: Equatable, B: Equatable,
+        C: Equatable, D: Equatable, E: Equatable, F: Equatable, G: Equatable {
+            assertionClosure = {
+                return $0.assertCalled(with: arguments)
+            }
+    }
+
+    /// Instantiates `MethodCall` with given arguments.
+    /// - Parameter arguments: A tuple of types `A`, `B`, `C`, `D`, `E`, `F`, `G`, `H`, where these types are `Equatable`.
+    public init<A, B, C, D, E, F, G, H>(arguments: (A, B, C, D, E, F, G, H)) where A: Equatable, B: Equatable,
+        C: Equatable, D: Equatable, E: Equatable, F: Equatable, G: Equatable, H: Equatable {
+            assertionClosure = {
+                return $0.assertCalled(with: arguments)
+            }
+    }
+
+    /// Instantiates `MethodCall` with given arguments.
+    /// - Parameter arguments: A tuple of types `A`, `B`, `C`, `D`, `E`, `F`, `G`, `H`, `I`, where these types are `Equatable`.
+    public init<A, B, C, D, E, F, G, H, I>(arguments: (A, B, C, D, E, F, G, H, I)) where A: Equatable, B: Equatable,
+        C: Equatable, D: Equatable, E: Equatable, F: Equatable, G: Equatable, H: Equatable, I: Equatable {
+            assertionClosure = {
+                return $0.assertCalled(with: arguments)
+            }
+    }
+}

--- a/Sources/Entities/RecordedMethodCall.swift
+++ b/Sources/Entities/RecordedMethodCall.swift
@@ -17,7 +17,7 @@ public struct RecordedMethodCall {
     /// Asserts that recorded call is equal to expected one.
     /// - Parameter methodCall: Method call to compare with.
     /// - Returns: Quality result.
-    public func assertEquals(to methodCall: MethodCall) -> Result<Void, Failure> {
+    public func assertEquals(to methodCall: MethodCall) -> Result<Void, AssertionFailure> {
         return methodCall.assertEquals(to: self)
     }
 }
@@ -27,7 +27,7 @@ extension RecordedMethodCall {
     /// Asserts that recorded call has expected argument.
     /// - Parameter argument: An argument of type `A`, where `A` is `Equatable`.
     /// - Returns: Assertion result.
-    public func assertCalled<A>(with argument: A) -> Result<Void, Failure> where A: Equatable {
+    public func assertCalled<A>(with argument: A) -> Result<Void, AssertionFailure> where A: Equatable {
         return arguments.assertSize(of: 1)
             .flatMap { arguments[0].assertEqual(argument) }
     }
@@ -35,7 +35,8 @@ extension RecordedMethodCall {
     /// Asserts that recorded call has expected arguments.
     /// - Parameter arguments: A tuple of types `A`, `B`, where these types are `Equatable`.
     /// - Returns: Assertion result.
-    public func assertCalled<A, B>(with arguments: (A, B)) -> Result<Void, Failure> where A: Equatable, B: Equatable {
+    public func assertCalled<A, B>(with arguments: (A, B)) -> Result<Void, AssertionFailure>
+        where A: Equatable, B: Equatable {
             return self.arguments.assertSize(of: 2)
                 .flatMap { self.arguments[0].assertEqual(arguments.0) }
                 .flatMap { self.arguments[1].assertEqual(arguments.1) }
@@ -44,7 +45,7 @@ extension RecordedMethodCall {
     /// Asserts that recorded call has expected arguments.
     /// - Parameter arguments: A tuple of types `A`, `B`, `C`, where these types are `Equatable`.
     /// - Returns: Assertion result.
-    public func assertCalled<A, B, C>(with arguments: (A, B, C)) -> Result<Void, Failure>
+    public func assertCalled<A, B, C>(with arguments: (A, B, C)) -> Result<Void, AssertionFailure>
         where A: Equatable, B: Equatable, C: Equatable {
             return self.arguments.assertSize(of: 3)
                 .flatMap { self.arguments[0].assertEqual(arguments.0) }
@@ -55,7 +56,7 @@ extension RecordedMethodCall {
     /// Asserts that recorded call has expected arguments.
     /// - Parameter arguments: A tuple of types `A`, `B`, `C`, `D`, where these types are `Equatable`.
     /// - Returns: Assertion result.
-    public func assertCalled<A, B, C, D>(with arguments: (A, B, C, D)) -> Result<Void, Failure>
+    public func assertCalled<A, B, C, D>(with arguments: (A, B, C, D)) -> Result<Void, AssertionFailure>
         where A: Equatable, B: Equatable, C: Equatable, D: Equatable {
             return self.arguments.assertSize(of: 4)
                 .flatMap { self.arguments[0].assertEqual(arguments.0) }
@@ -67,7 +68,7 @@ extension RecordedMethodCall {
     /// Asserts that recorded call has expected arguments.
     /// - Parameter arguments: A tuple of types `A`, `B`, `C`, `D`, `E`, where these types are `Equatable`.
     /// - Returns: Assertion result.
-    public func assertCalled<A, B, C, D, E>(with arguments: (A, B, C, D, E)) -> Result<Void, Failure>
+    public func assertCalled<A, B, C, D, E>(with arguments: (A, B, C, D, E)) -> Result<Void, AssertionFailure>
         where A: Equatable, B: Equatable, C: Equatable, D: Equatable, E: Equatable {
             return self.arguments.assertSize(of: 5)
                 .flatMap { self.arguments[0].assertEqual(arguments.0) }
@@ -77,11 +78,10 @@ extension RecordedMethodCall {
                 .flatMap { self.arguments[4].assertEqual(arguments.4) }
     }
 
-
     /// Asserts that recorded call has expected arguments.
     /// - Parameter arguments: A tuple of types `A`, `B`, `C`, `D`, `E`, `F`, where these types are `Equatable`.
     /// - Returns: Assertion result.
-    public func assertCalled<A, B, C, D, E, F>(with arguments: (A, B, C, D, E, F)) -> Result<Void, Failure>
+    public func assertCalled<A, B, C, D, E, F>(with arguments: (A, B, C, D, E, F)) -> Result<Void, AssertionFailure>
         where A: Equatable, B: Equatable, C: Equatable, D: Equatable, E: Equatable, F: Equatable {
             return self.arguments.assertSize(of: 6)
                 .flatMap { self.arguments[0].assertEqual(arguments.0) }
@@ -95,8 +95,9 @@ extension RecordedMethodCall {
     /// Asserts that recorded call has expected arguments.
     /// - Parameter arguments: A tuple of types `A`, `B`, `C`, `D`, `E`, `F`, `G`, where these types are `Equatable`.
     /// - Returns: Assertion result.
-    public func assertCalled<A, B, C, D, E, F, G>(with arguments: (A, B, C, D, E, F, G)) -> Result<Void, Failure>
-        where A: Equatable, B: Equatable, C: Equatable, D: Equatable, E: Equatable, F: Equatable, G: Equatable {
+    public func assertCalled<A, B, C, D, E, F, G>(with arguments: (A, B, C, D, E, F, G))
+        -> Result<Void, AssertionFailure> where A: Equatable, B: Equatable, C: Equatable, D: Equatable, E: Equatable,
+        F: Equatable, G: Equatable {
             return self.arguments.assertSize(of: 7)
                 .flatMap { self.arguments[0].assertEqual(arguments.0) }
                 .flatMap { self.arguments[1].assertEqual(arguments.1) }
@@ -110,9 +111,9 @@ extension RecordedMethodCall {
     /// Asserts that recorded call has expected arguments.
     /// - Parameter arguments: A tuple of types `A`, `B`, `C`, `D`, `E`, `F`, `G`, `H`, where these types are `Equatable`.
     /// - Returns: Assertion result.
-    public func assertCalled<A, B, C, D, E, F, G, H>(with arguments: (A, B, C, D, E, F, G, H)) -> Result<Void, Failure>
-        where A: Equatable, B: Equatable, C: Equatable, D: Equatable, E: Equatable, F: Equatable, G: Equatable,
-        H: Equatable {
+    public func assertCalled<A, B, C, D, E, F, G, H>(with arguments: (A, B, C, D, E, F, G, H))
+        -> Result<Void, AssertionFailure> where A: Equatable, B: Equatable, C: Equatable, D: Equatable, E: Equatable,
+        F: Equatable, G: Equatable, H: Equatable {
             return self.arguments.assertSize(of: 8)
                 .flatMap { self.arguments[0].assertEqual(arguments.0) }
                 .flatMap { self.arguments[1].assertEqual(arguments.1) }
@@ -128,7 +129,7 @@ extension RecordedMethodCall {
     /// - Parameter arguments: A tuple of types `A`, `B`, `C`, `D`, `E`, `F`, `G`, `H`, `I`, where these types are `Equatable`.
     /// - Returns: Assertion result.
     public func assertCalled<A, B, C, D, E, F, G, H, I>(with arguments: (A, B, C, D, E, F, G, H, I))
-        -> Result<Void, Failure> where A: Equatable, B: Equatable, C: Equatable, D: Equatable, E: Equatable,
+        -> Result<Void, AssertionFailure> where A: Equatable, B: Equatable, C: Equatable, D: Equatable, E: Equatable,
         F: Equatable, G: Equatable, H: Equatable, I: Equatable {
             return self.arguments.assertSize(of: 9)
                 .flatMap { self.arguments[0].assertEqual(arguments.0) }

--- a/Sources/Entities/RecordedMethodCall.swift
+++ b/Sources/Entities/RecordedMethodCall.swift
@@ -1,0 +1,144 @@
+/// Represents method call that is recorded during `Spy` invocation.
+public struct RecordedMethodCall {
+
+    /// Maximum quantity of arguments which could be recorded.
+    static let argumentsLimit = 9
+
+    /// Recorded arguments.
+    public let arguments: [Argument]
+
+    init(arguments: [Any]) {
+        self.arguments = arguments
+            .prefix(RecordedMethodCall.argumentsLimit)
+            .enumerated()
+            .map { Argument(value: $0.element, position: .init($0.offset)) }
+    }
+
+    /// Asserts that recorded call is equal to expected one.
+    /// - Parameter methodCall: Method call to compare with.
+    /// - Returns: Quality result.
+    public func assertEquals(to methodCall: MethodCall) -> Result<Void, Failure> {
+        return methodCall.assertEquals(to: self)
+    }
+}
+
+extension RecordedMethodCall {
+
+    /// Asserts that recorded call has expected argument.
+    /// - Parameter argument: An argument of type `A`, where `A` is `Equatable`.
+    /// - Returns: Assertion result.
+    public func assertCalled<A>(with argument: A) -> Result<Void, Failure> where A: Equatable {
+        return arguments.assertSize(of: 1)
+            .flatMap { arguments[0].assertEqual(argument) }
+    }
+
+    /// Asserts that recorded call has expected arguments.
+    /// - Parameter arguments: A tuple of types `A`, `B`, where these types are `Equatable`.
+    /// - Returns: Assertion result.
+    public func assertCalled<A, B>(with arguments: (A, B)) -> Result<Void, Failure> where A: Equatable, B: Equatable {
+            return self.arguments.assertSize(of: 2)
+                .flatMap { self.arguments[0].assertEqual(arguments.0) }
+                .flatMap { self.arguments[1].assertEqual(arguments.1) }
+    }
+
+    /// Asserts that recorded call has expected arguments.
+    /// - Parameter arguments: A tuple of types `A`, `B`, `C`, where these types are `Equatable`.
+    /// - Returns: Assertion result.
+    public func assertCalled<A, B, C>(with arguments: (A, B, C)) -> Result<Void, Failure>
+        where A: Equatable, B: Equatable, C: Equatable {
+            return self.arguments.assertSize(of: 3)
+                .flatMap { self.arguments[0].assertEqual(arguments.0) }
+                .flatMap { self.arguments[1].assertEqual(arguments.1) }
+                .flatMap { self.arguments[2].assertEqual(arguments.2) }
+    }
+
+    /// Asserts that recorded call has expected arguments.
+    /// - Parameter arguments: A tuple of types `A`, `B`, `C`, `D`, where these types are `Equatable`.
+    /// - Returns: Assertion result.
+    public func assertCalled<A, B, C, D>(with arguments: (A, B, C, D)) -> Result<Void, Failure>
+        where A: Equatable, B: Equatable, C: Equatable, D: Equatable {
+            return self.arguments.assertSize(of: 4)
+                .flatMap { self.arguments[0].assertEqual(arguments.0) }
+                .flatMap { self.arguments[1].assertEqual(arguments.1) }
+                .flatMap { self.arguments[2].assertEqual(arguments.2) }
+                .flatMap { self.arguments[3].assertEqual(arguments.3) }
+    }
+
+    /// Asserts that recorded call has expected arguments.
+    /// - Parameter arguments: A tuple of types `A`, `B`, `C`, `D`, `E`, where these types are `Equatable`.
+    /// - Returns: Assertion result.
+    public func assertCalled<A, B, C, D, E>(with arguments: (A, B, C, D, E)) -> Result<Void, Failure>
+        where A: Equatable, B: Equatable, C: Equatable, D: Equatable, E: Equatable {
+            return self.arguments.assertSize(of: 5)
+                .flatMap { self.arguments[0].assertEqual(arguments.0) }
+                .flatMap { self.arguments[1].assertEqual(arguments.1) }
+                .flatMap { self.arguments[2].assertEqual(arguments.2) }
+                .flatMap { self.arguments[3].assertEqual(arguments.3) }
+                .flatMap { self.arguments[4].assertEqual(arguments.4) }
+    }
+
+
+    /// Asserts that recorded call has expected arguments.
+    /// - Parameter arguments: A tuple of types `A`, `B`, `C`, `D`, `E`, `F`, where these types are `Equatable`.
+    /// - Returns: Assertion result.
+    public func assertCalled<A, B, C, D, E, F>(with arguments: (A, B, C, D, E, F)) -> Result<Void, Failure>
+        where A: Equatable, B: Equatable, C: Equatable, D: Equatable, E: Equatable, F: Equatable {
+            return self.arguments.assertSize(of: 6)
+                .flatMap { self.arguments[0].assertEqual(arguments.0) }
+                .flatMap { self.arguments[1].assertEqual(arguments.1) }
+                .flatMap { self.arguments[2].assertEqual(arguments.2) }
+                .flatMap { self.arguments[3].assertEqual(arguments.3) }
+                .flatMap { self.arguments[4].assertEqual(arguments.4) }
+                .flatMap { self.arguments[5].assertEqual(arguments.5) }
+    }
+
+    /// Asserts that recorded call has expected arguments.
+    /// - Parameter arguments: A tuple of types `A`, `B`, `C`, `D`, `E`, `F`, `G`, where these types are `Equatable`.
+    /// - Returns: Assertion result.
+    public func assertCalled<A, B, C, D, E, F, G>(with arguments: (A, B, C, D, E, F, G)) -> Result<Void, Failure>
+        where A: Equatable, B: Equatable, C: Equatable, D: Equatable, E: Equatable, F: Equatable, G: Equatable {
+            return self.arguments.assertSize(of: 7)
+                .flatMap { self.arguments[0].assertEqual(arguments.0) }
+                .flatMap { self.arguments[1].assertEqual(arguments.1) }
+                .flatMap { self.arguments[2].assertEqual(arguments.2) }
+                .flatMap { self.arguments[3].assertEqual(arguments.3) }
+                .flatMap { self.arguments[4].assertEqual(arguments.4) }
+                .flatMap { self.arguments[5].assertEqual(arguments.5) }
+                .flatMap { self.arguments[6].assertEqual(arguments.6) }
+    }
+
+    /// Asserts that recorded call has expected arguments.
+    /// - Parameter arguments: A tuple of types `A`, `B`, `C`, `D`, `E`, `F`, `G`, `H`, where these types are `Equatable`.
+    /// - Returns: Assertion result.
+    public func assertCalled<A, B, C, D, E, F, G, H>(with arguments: (A, B, C, D, E, F, G, H)) -> Result<Void, Failure>
+        where A: Equatable, B: Equatable, C: Equatable, D: Equatable, E: Equatable, F: Equatable, G: Equatable,
+        H: Equatable {
+            return self.arguments.assertSize(of: 8)
+                .flatMap { self.arguments[0].assertEqual(arguments.0) }
+                .flatMap { self.arguments[1].assertEqual(arguments.1) }
+                .flatMap { self.arguments[2].assertEqual(arguments.2) }
+                .flatMap { self.arguments[3].assertEqual(arguments.3) }
+                .flatMap { self.arguments[4].assertEqual(arguments.4) }
+                .flatMap { self.arguments[5].assertEqual(arguments.5) }
+                .flatMap { self.arguments[6].assertEqual(arguments.6) }
+                .flatMap { self.arguments[7].assertEqual(arguments.7) }
+    }
+
+    /// Asserts that recorded call has expected arguments.
+    /// - Parameter arguments: A tuple of types `A`, `B`, `C`, `D`, `E`, `F`, `G`, `H`, `I`, where these types are `Equatable`.
+    /// - Returns: Assertion result.
+    public func assertCalled<A, B, C, D, E, F, G, H, I>(with arguments: (A, B, C, D, E, F, G, H, I))
+        -> Result<Void, Failure> where A: Equatable, B: Equatable, C: Equatable, D: Equatable, E: Equatable,
+        F: Equatable, G: Equatable, H: Equatable, I: Equatable {
+            return self.arguments.assertSize(of: 9)
+                .flatMap { self.arguments[0].assertEqual(arguments.0) }
+                .flatMap { self.arguments[1].assertEqual(arguments.1) }
+                .flatMap { self.arguments[2].assertEqual(arguments.2) }
+                .flatMap { self.arguments[3].assertEqual(arguments.3) }
+                .flatMap { self.arguments[4].assertEqual(arguments.4) }
+                .flatMap { self.arguments[5].assertEqual(arguments.5) }
+                .flatMap { self.arguments[6].assertEqual(arguments.6) }
+                .flatMap { self.arguments[7].assertEqual(arguments.7) }
+                .flatMap { self.arguments[8].assertEqual(arguments.8) }
+    }
+}

--- a/Sources/Entities/Spy.swift
+++ b/Sources/Entities/Spy.swift
@@ -1,7 +1,7 @@
 /// A `Spy` is a `Stub` that also records information about call.
 public final class Spy<Value> {
 
-    public private(set) var calls = [MethodCall]()
+    public private(set) var calls = [RecordedMethodCall]()
 
     private var stub: Stub<Value>
 
@@ -13,14 +13,8 @@ public final class Spy<Value> {
 extension Spy: Invokable {
 
     public func invoke(arguments: [Any]) -> Value {
-        let callArguments = arguments.map { Argument(value: $0) }
-        calls.append(MethodCall(arguments: callArguments))
+        calls.append(RecordedMethodCall(arguments: arguments))
 
         return stub.invoke(arguments: arguments)
     }
-}
-
-public struct MethodCall {
-
-    public let arguments: [Argument]
 }

--- a/Sources/FailureReporter/AssertionFailure.swift
+++ b/Sources/FailureReporter/AssertionFailure.swift
@@ -1,4 +1,4 @@
-public enum Failure: Error {
+public enum AssertionFailure: Error {
 
     case nilValue
     case argumentsCountMismatch(expectedCount: Int, providedCount: Int)
@@ -10,7 +10,7 @@ public enum Failure: Error {
     case expectedToBeCalledTimes(expectedCount: Int, calledCount: Int)
 }
 
-extension Failure {
+extension AssertionFailure {
 
     public var message: String {
         switch self {

--- a/Sources/FailureReporter/DefaultFailureReportHandler.swift
+++ b/Sources/FailureReporter/DefaultFailureReportHandler.swift
@@ -2,11 +2,11 @@ import XCTest
 
 final class DefaultFailureReportHandler: FailureReportHandler {
 
-    func handleFailure(_ failure: Failure, location: ReportLocation) {
+    func handleFailure(_ failure: AssertionFailure, location: ReportLocation) {
         XCTFail(failure.message, file: location.file, line: location.line)
     }
 
-    func handleFatalError(_ failure: Failure, location: ReportLocation?) -> Never {
+    func handleFatalError(_ failure: AssertionFailure, location: ReportLocation?) -> Never {
         #if !os(Linux)
         NSException(name: .internalInconsistencyException,
                     reason: failure.message,

--- a/Sources/FailureReporter/Failure.swift
+++ b/Sources/FailureReporter/Failure.swift
@@ -1,4 +1,4 @@
-public enum Failure {
+public enum Failure: Error {
 
     case nilValue
     case argumentsCountMismatch(expectedCount: Int, providedCount: Int)

--- a/Sources/FailureReporter/FailureReportHandler.swift
+++ b/Sources/FailureReporter/FailureReportHandler.swift
@@ -6,6 +6,6 @@ public struct ReportLocation {
 
 public protocol FailureReportHandler {
 
-    func handleFailure(_ failure: Failure, location: ReportLocation)
-    func handleFatalError(_ failure: Failure, location: ReportLocation?) -> Never
+    func handleFailure(_ failure: AssertionFailure, location: ReportLocation)
+    func handleFatalError(_ failure: AssertionFailure, location: ReportLocation?) -> Never
 }

--- a/Sources/XCTAssert/Result+Guava.swift
+++ b/Sources/XCTAssert/Result+Guava.swift
@@ -1,4 +1,4 @@
-extension Result where Failure == Guava.Failure {
+extension Result where Failure == AssertionFailure {
 
     /// Sends report to `FailureReporter` if result is `failure`.
     /// - Parameters:

--- a/Sources/XCTAssert/Result+Guava.swift
+++ b/Sources/XCTAssert/Result+Guava.swift
@@ -1,0 +1,12 @@
+extension Result where Failure == Guava.Failure {
+
+    /// Sends report to `FailureReporter` if result is `failure`.
+    /// - Parameters:
+    ///   - file: The file in which failure occurred. Defaults to the file name of the test case in which this function was called.
+    ///   - line: The line number on which failure occurred. Defaults to the line number on which this function was called.
+    func reportFailure(file: StaticString, line: UInt) {
+        if case .failure(let failure) = self {
+            FailureReporter.handler.handleFailure(failure, location: .init(file: file, line: line))
+        }
+    }
+}

--- a/Sources/XCTAssert/XCTAssert.swift
+++ b/Sources/XCTAssert/XCTAssert.swift
@@ -58,9 +58,7 @@ public func XCTAssertCalled<Out, A>(_ spy: Spy<Out>,
                                     file: StaticString = #file,
                                     line: UInt = #line) where A: Equatable {
     XCTAssertCalled(spy, file: file, line: line)
-    guard let callArguments = spy.calls.last?.arguments,
-        callArguments.assertSize(of: 1, file: file, line: line),
-        callArguments[0].assertEqual(argument, position: .first, file: file, line: line) else { return }
+    spy.calls.last?.assertCalled(with: argument).reportFailure(file: file, line: line)
 }
 
 /// Asserts that spy was called with two arguments.
@@ -75,10 +73,7 @@ public func XCTAssertCalled<Out, A, B>(_ spy: Spy<Out>,
                                        line: UInt = #line)
     where A: Equatable, B: Equatable {
         XCTAssertCalled(spy, file: file, line: line)
-        guard let callArguments = spy.calls.last?.arguments,
-            callArguments.assertSize(of: 2, file: file, line: line),
-            callArguments[0].assertEqual(arguments.0, position: .first, file: file, line: line),
-            callArguments[1].assertEqual(arguments.1, position: .second, file: file, line: line) else { return }
+        spy.calls.last?.assertCalled(with: arguments).reportFailure(file: file, line: line)
 }
 
 /// Asserts that spy was called with three arguments.
@@ -93,11 +88,7 @@ public func XCTAssertCalled<Out, A, B, C>(_ spy: Spy<Out>,
                                           line: UInt = #line)
     where A: Equatable, B: Equatable, C: Equatable {
         XCTAssertCalled(spy, file: file, line: line)
-        guard let callArguments = spy.calls.last?.arguments,
-            callArguments.assertSize(of: 3, file: file, line: line),
-            callArguments[0].assertEqual(arguments.0, position: .first, file: file, line: line),
-            callArguments[1].assertEqual(arguments.1, position: .second, file: file, line: line),
-            callArguments[2].assertEqual(arguments.2, position: .third, file: file, line: line) else { return }
+        spy.calls.last?.assertCalled(with: arguments).reportFailure(file: file, line: line)
 }
 
 /// Asserts that spy was called with four arguments.
@@ -112,12 +103,7 @@ public func XCTAssertCalled<Out, A, B, C, D>(_ spy: Spy<Out>,
                                              line: UInt = #line)
     where A: Equatable, B: Equatable, C: Equatable, D: Equatable {
         XCTAssertCalled(spy, file: file, line: line)
-        guard let callArguments = spy.calls.last?.arguments,
-            callArguments.assertSize(of: 4, file: file, line: line),
-            callArguments[0].assertEqual(arguments.0, position: .first, file: file, line: line),
-            callArguments[1].assertEqual(arguments.1, position: .second, file: file, line: line),
-            callArguments[2].assertEqual(arguments.2, position: .third, file: file, line: line),
-            callArguments[3].assertEqual(arguments.3, position: .fourth, file: file, line: line) else { return }
+        spy.calls.last?.assertCalled(with: arguments).reportFailure(file: file, line: line)
 }
 
 /// Asserts that spy was called with five arguments.
@@ -132,13 +118,7 @@ public func XCTAssertCalled<Out, A, B, C, D, E>(_ spy: Spy<Out>,
                                                 line: UInt = #line)
     where A: Equatable, B: Equatable, C: Equatable, D: Equatable, E: Equatable {
         XCTAssertCalled(spy, file: file, line: line)
-        guard let callArguments = spy.calls.last?.arguments,
-            callArguments.assertSize(of: 5, file: file, line: line),
-            callArguments[0].assertEqual(arguments.0, position: .first, file: file, line: line),
-            callArguments[1].assertEqual(arguments.1, position: .second, file: file, line: line),
-            callArguments[2].assertEqual(arguments.2, position: .third, file: file, line: line),
-            callArguments[3].assertEqual(arguments.3, position: .fourth, file: file, line: line),
-            callArguments[4].assertEqual(arguments.4, position: .fifth, file: file, line: line) else { return }
+        spy.calls.last?.assertCalled(with: arguments).reportFailure(file: file, line: line)
 }
 
 /// Asserts that spy was called with six arguments.
@@ -153,14 +133,7 @@ public func XCTAssertCalled<Out, A, B, C, D, E, F>(_ spy: Spy<Out>,
                                                    line: UInt = #line)
     where A: Equatable, B: Equatable, C: Equatable, D: Equatable, E: Equatable, F: Equatable {
         XCTAssertCalled(spy, file: file, line: line)
-        guard let callArguments = spy.calls.last?.arguments,
-            callArguments.assertSize(of: 6, file: file, line: line),
-            callArguments[0].assertEqual(arguments.0, position: .first, file: file, line: line),
-            callArguments[1].assertEqual(arguments.1, position: .second, file: file, line: line),
-            callArguments[2].assertEqual(arguments.2, position: .third, file: file, line: line),
-            callArguments[3].assertEqual(arguments.3, position: .fourth, file: file, line: line),
-            callArguments[4].assertEqual(arguments.4, position: .fifth, file: file, line: line),
-            callArguments[5].assertEqual(arguments.5, position: .sixth, file: file, line: line) else { return }
+        spy.calls.last?.assertCalled(with: arguments).reportFailure(file: file, line: line)
 }
 
 /// Asserts that spy was called with seven arguments.
@@ -175,15 +148,7 @@ public func XCTAssertCalled<Out, A, B, C, D, E, F, G>(_ spy: Spy<Out>,
                                                       line: UInt = #line)
     where A: Equatable, B: Equatable, C: Equatable, D: Equatable, E: Equatable, F: Equatable, G: Equatable {
         XCTAssertCalled(spy, file: file, line: line)
-        guard let callArguments = spy.calls.last?.arguments,
-            callArguments.assertSize(of: 7, file: file, line: line),
-            callArguments[0].assertEqual(arguments.0, position: .first, file: file, line: line),
-            callArguments[1].assertEqual(arguments.1, position: .second, file: file, line: line),
-            callArguments[2].assertEqual(arguments.2, position: .third, file: file, line: line),
-            callArguments[3].assertEqual(arguments.3, position: .fourth, file: file, line: line),
-            callArguments[4].assertEqual(arguments.4, position: .fifth, file: file, line: line),
-            callArguments[5].assertEqual(arguments.5, position: .sixth, file: file, line: line),
-            callArguments[6].assertEqual(arguments.6, position: .seventh, file: file, line: line) else { return }
+        spy.calls.last?.assertCalled(with: arguments).reportFailure(file: file, line: line)
 }
 
 /// Asserts that spy was called with eight arguments.
@@ -199,16 +164,7 @@ public func XCTAssertCalled<Out, A, B, C, D, E, F, G, H>(_ spy: Spy<Out>,
     where A: Equatable, B: Equatable, C: Equatable, D: Equatable, E: Equatable, F: Equatable, G: Equatable,
     H: Equatable {
         XCTAssertCalled(spy, file: file, line: line)
-        guard let callArguments = spy.calls.last?.arguments,
-            callArguments.assertSize(of: 8, file: file, line: line),
-            callArguments[0].assertEqual(arguments.0, position: .first, file: file, line: line),
-            callArguments[1].assertEqual(arguments.1, position: .second, file: file, line: line),
-            callArguments[2].assertEqual(arguments.2, position: .third, file: file, line: line),
-            callArguments[3].assertEqual(arguments.3, position: .fourth, file: file, line: line),
-            callArguments[4].assertEqual(arguments.4, position: .fifth, file: file, line: line),
-            callArguments[5].assertEqual(arguments.5, position: .sixth, file: file, line: line),
-            callArguments[6].assertEqual(arguments.6, position: .seventh, file: file, line: line),
-            callArguments[7].assertEqual(arguments.7, position: .eighth, file: file, line: line) else { return }
+        spy.calls.last?.assertCalled(with: arguments).reportFailure(file: file, line: line)
 }
 
 /// Asserts that spy was called with nine arguments.
@@ -224,15 +180,5 @@ public func XCTAssertCalled<Out, A, B, C, D, E, F, G, H, I>(_ spy: Spy<Out>,
     where A: Equatable, B: Equatable, C: Equatable, D: Equatable, E: Equatable, F: Equatable, G: Equatable,
     H: Equatable, I: Equatable {
         XCTAssertCalled(spy, file: file, line: line)
-        guard let callArguments = spy.calls.last?.arguments,
-            callArguments.assertSize(of: 9, file: file, line: line),
-            callArguments[0].assertEqual(arguments.0, position: .first, file: file, line: line),
-            callArguments[1].assertEqual(arguments.1, position: .second, file: file, line: line),
-            callArguments[2].assertEqual(arguments.2, position: .third, file: file, line: line),
-            callArguments[3].assertEqual(arguments.3, position: .fourth, file: file, line: line),
-            callArguments[4].assertEqual(arguments.4, position: .fifth, file: file, line: line),
-            callArguments[5].assertEqual(arguments.5, position: .sixth, file: file, line: line),
-            callArguments[6].assertEqual(arguments.6, position: .seventh, file: file, line: line),
-            callArguments[7].assertEqual(arguments.7, position: .eighth, file: file, line: line),
-            callArguments[8].assertEqual(arguments.8, position: .ninth, file: file, line: line) else { return }
+        spy.calls.last?.assertCalled(with: arguments).reportFailure(file: file, line: line)
 }

--- a/Tests/GuavaTests/TestableReporter.swift
+++ b/Tests/GuavaTests/TestableReporter.swift
@@ -4,11 +4,11 @@ final class TestableReporter: FailureReportHandler {
 
     var passedFailureMessage: String?
 
-    func handleFailure(_ failure: Failure, location: ReportLocation) {
+    func handleFailure(_ failure: AssertionFailure, location: ReportLocation) {
         passedFailureMessage = failure.message
     }
 
-    func handleFatalError(_ failure: Failure, location: ReportLocation?) -> Never {
+    func handleFatalError(_ failure: AssertionFailure, location: ReportLocation?) -> Never {
         fatalError(failure.message)
     }
 }


### PR DESCRIPTION
## Introduction 
Introduce a new assertion mechanism.

## Motivation
The current approach lacks flexibility. 

- All assertion logic encapsulated inside the library. The only way to receive assertion results is the `FailureReporter` entity.
- It's nearly impossible to integrate `Guava` with third-party libraries (e.g. [Nimble](https://github.com/Quick/Nimble)). Lots of assertion logic should be rewritten from the ground up.

## Solution
- Move all `FailureReporter` usage to the `XCTAssert` module except for cases when we need to send `fatalFailure` with `Never` as return type.
- Update all assertion methods to return `Result<Void, AssertionFailure>` instead of `Void`.
- Rename `MethodCall` to `RecordedMethodCall` to represent stored `Spy` invocation calls.
- Update `MethodCall` to represent the expected method call during calls assertion.
- Update `Argument.Position` to be instantiated from its index in an array of arguments.