### PR TITLE
Make non-async factories thread safe

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     name: Building on ubuntu-latest with Swift ${{ matrix.tag }}
     strategy:
       matrix:
-        tag: ['5.5']
+        tag: ['5.10']
     runs-on: ubuntu-latest
     container:
       image: swift:${{ matrix.tag }}

--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,5 @@ fastlane/test_output
 # SwiftPM
 
 .swiftpm/
+
+*.DS_Store

--- a/Package.swift
+++ b/Package.swift
@@ -1,11 +1,11 @@
-// swift-tools-version:5.0
+// swift-tools-version:5.10
 
 import PackageDescription
 
 let package = Package(
     name: "Guava",
     platforms: [
-        .iOS(.v12), .macOS(.v10_10)
+        .iOS(.v12), .macOS(.v10_13)
     ],
     products: [
         .library(

--- a/Sources/Entities/AsyncInvokable.swift
+++ b/Sources/Entities/AsyncInvokable.swift
@@ -1,6 +1,6 @@
 /// Describes an entity which could be called asyncrounosly with specific amount of arguments.
 @available(iOS 13, macOS 10.15, *)
-protocol AsyncInvokable {
+protocol AsyncInvokable: Sendable {
 
     associatedtype Output
 

--- a/Sources/Entities/Fake.swift
+++ b/Sources/Entities/Fake.swift
@@ -1,5 +1,5 @@
 /// A `Fake` allows to swap testable entity implementation with stored one.
-final class Fake<Value> {
+final class Fake<Value>: Sendable {
 
     private let closure: Closure<Value>
 

--- a/Sources/Entities/Spy.swift
+++ b/Sources/Entities/Spy.swift
@@ -1,6 +1,9 @@
-/// A `Spy` is a `Stub` that also records information about call.
-public final class Spy<Value> {
+import Foundation
 
+/// A `Spy` is a `Stub` that also records information about call.
+public final class Spy<Value>: @unchecked Sendable {
+
+    private let lock = NSLock()
     public private(set) var calls = [RecordedMethodCall]()
 
     private var stub: Stub<Value>
@@ -17,17 +20,21 @@ public final class Spy<Value> {
 extension Spy: Invokable {
 
     public func invoke(arguments: [Any]) -> Value {
-        calls.append(RecordedMethodCall(arguments: arguments))
+        return lock.withLock {
+            calls.append(RecordedMethodCall(arguments: arguments))
 
-        return stub.invoke(arguments: arguments)
+            return stub.invoke(arguments: arguments)
+        }
     }
 }
 
 extension Spy: ThrowingInvokable {
 
     func throwingInvoke(arguments: [Any]) throws -> Value {
-        calls.append(RecordedMethodCall(arguments: arguments))
+        return try lock.withLock {
+            calls.append(RecordedMethodCall(arguments: arguments))
 
-        return try stub.throwingInvoke(arguments: arguments)
+            return try stub.throwingInvoke(arguments: arguments)
+        }
     }
 }

--- a/Sources/Entities/Stub.swift
+++ b/Sources/Entities/Stub.swift
@@ -1,5 +1,5 @@
 /// A `Stub` provides hardcoded answers to calls made during the test.
-final class Stub<Value> {
+final class Stub<Value>: @unchecked Sendable {
 
     private let stubbedValue: Result<Value, Error>
     private let delayInNanoseconds: UInt64

--- a/Sources/Entities/ThrowingAsyncInvokable.swift
+++ b/Sources/Entities/ThrowingAsyncInvokable.swift
@@ -1,6 +1,6 @@
 /// Describes an entity which could throw and could be called asyncrounosly with specific amount of arguments.
 @available(iOS 13, macOS 10.15, *)
-protocol ThrowingAsyncInvokable {
+protocol ThrowingAsyncInvokable: Sendable {
 
     associatedtype Output
 

--- a/Sources/Extensions/NSLock+.swift
+++ b/Sources/Extensions/NSLock+.swift
@@ -1,0 +1,12 @@
+#if os(Linux)
+import Foundation
+
+extension NSLock {
+
+    func withLock<R>(_ body: () throws -> R) rethrows -> R {
+        lock()
+        defer { unlock() }
+        return try body()
+    }
+}
+#endif


### PR DESCRIPTION
Sometimes the non-async factories can be used in the multithreaded context. This PR adds `Sendable` conformance to these factories with appropriate locking to avoid data races.