### PR TITLE
Fix XCTFail not found error

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,8 @@ let package = Package(
         .target(
             name: "Guava",
             dependencies: [],
-            path: "Sources"),
+            path: "Sources",
+            linkerSettings: [.linkedFramework("XCTest")]),
         .testTarget(
             name: "GuavaTests",
             dependencies: ["Guava"]),


### PR DESCRIPTION
Add a link to the XCTest to fix the `XCTFail not found` error