### PR TITLE
Entities: Remove AssertionFailure.taskExplicitlyCanceled case

### DIFF
--- a/Sources/Entities/AsyncStub.swift
+++ b/Sources/Entities/AsyncStub.swift
@@ -27,11 +27,7 @@ extension AsyncStub: AsyncInvokable {
                 .handleFatalError(.testDoubleTypeMismatch(expected: "Async", received: "Throwing"), location: nil)
         }
 
-        do {
-            try await Task.sleep(nanoseconds: delayInNanoseconds)
-        } catch {
-            FailureReporter.handler.handleFatalError(.taskExplicitlyCanceled, location: nil)
-        }
+        try? await Task.sleep(nanoseconds: delayInNanoseconds)
         return result
     }
 }
@@ -41,11 +37,7 @@ extension AsyncStub: ThrowingAsyncInvokable {
 
     @Sendable
     func throwingAsyncInvoke(arguments: [Any]) async throws -> Value {
-        do {
-            try await Task.sleep(nanoseconds: delayInNanoseconds)
-        } catch {
-            FailureReporter.handler.handleFatalError(.taskExplicitlyCanceled, location: nil)
-        }
+        try await Task.sleep(nanoseconds: delayInNanoseconds)
 
         switch stubbedValue {
         case .success(let value):

--- a/Sources/FailureReporter/AssertionFailure.swift
+++ b/Sources/FailureReporter/AssertionFailure.swift
@@ -9,7 +9,6 @@ public enum AssertionFailure: Error {
     case expectedToBeCalledOnce(calledCount: Int)
     case expectedToBeCalledTimes(expectedCount: Int, calledCount: Int)
     case testDoubleTypeMismatch(expected: String, received: String)
-    case taskExplicitlyCanceled
 }
 
 extension AssertionFailure {
@@ -34,8 +33,6 @@ extension AssertionFailure {
             return "Expected to be called \(expectedCount) time(s) but called \(calledCount) time(s)"
         case .testDoubleTypeMismatch(let expected, let received):
             return "Expected closure to be type of \(expected), received \(received)"
-        case .taskExplicitlyCanceled:
-            return "Task explicitly canceled"
         }
     }
 }


### PR DESCRIPTION
We need to be able to cancel the task ourselves and test this logic. The current assertion does not allow us to do this.